### PR TITLE
fix: issue with stretched news images home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -327,7 +327,6 @@ header {
 
 .news-img{
 	flex-shrink: 0;
-  width: 100%;
 	max-width: 100%;
 	max-height: 150px;
 	display: block;


### PR DESCRIPTION
When viewing the home page on smaller screens, the image aspect ratio is not preserved: 

![image](https://github.com/user-attachments/assets/5ca56e72-dade-4cd7-a55f-3f73f715192a)
